### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or Gradle:
     
 Add the XMLBundle
 
-    bootstrap.addBundle(new XMLBundle());
+    bootstrap.addBundle(new XmlBundle());
 
 Annotate your Resources:
 


### PR DESCRIPTION
Just two quick fixes in the README...

Just a side note and question. I've been compiling this guy with gradle and having maven install the jar and declaring the dependency in the pom. (We use maven for everything else although gradle looks nice so we may play with that later.) I tried to add jCenter and then add your project as a dependency....Eclipse seemed to resolve everything okay, but sadly when I tried to actually run the thing maven couldn't find any of the annotations, so I'm not sure if you have a bug in the dependencies of the 0.7.1-2 release or what. Let me know if maybe I'm doing something wrong?
